### PR TITLE
Feature/issue5 data block

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Dispatcher Demo (ddpdemo)
+# Data Dispatcher and Packager Demo (ddpdemo)
 
 ### Hints for building and running (KAB, 08-Sep-2020):
 

--- a/README.md
+++ b/README.md
@@ -20,4 +20,5 @@ To enable and view TRACE messages:
 * run the application to get the TRACE names populated in the TRACE buffer, if needed
 * `tlvls` to view the available TRACE names and their currently enabled levels
 * `tonM -n <TRACE_NAME> <level>` to enable a desired level (e.g. `tonM -n SimpleDiskWriter 15`)
+* re-run the application to get the TRACE messages output to the TRACE buffer
 * `tshow | tdelta -ct 1` to view the TRACE messages (in reverse order, with human-readable timestamps)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 * create a software work area
   * see https://github.com/DUNE-DAQ/appfwk/wiki/Compiling-and-running
 * clone this repo
-  * `cd <work_area>`
+  * `cd <MyTopDir>`
   * `git clone https://github.com/DUNE-DAQ/ddpdemo.git`)
 * build the software
   * `. ./setup_build_environment`
@@ -14,3 +14,10 @@
   * `. ./setup_runtime_environment`
   * `daq_application -c QueryResponseCommandFacility -j build/ddpdemo/test/disk_writer_demo.json`
     * use commands line `configure`, `start`, `stop`, and `quit`
+
+To enable and view TRACE messages:
+* `export TRACE_FILE=<MyTopDir>/log/<username>_dunedaq.trace`
+* run the application to get the TRACE names populated in the TRACE buffer, if needed
+* `tlvls` to view the available TRACE names and their currently enabled levels
+* `tonM -n <TRACE_NAME> <level>` to enable a desired level (e.g. `tonM -n SimpleDiskWriter 15`)
+* `tshow | tdelta -ct 1` to view the TRACE messages (in reverse order, with human-readable timestamps)

--- a/include/ddpdemo/KeyedDataBlock.hpp
+++ b/include/ddpdemo/KeyedDataBlock.hpp
@@ -9,7 +9,7 @@
 #ifndef DDPDEMO_INCLUDE_DDPDEMO_KEYEDDATABLOCK_HPP_
 #define DDPDEMO_INCLUDE_DDPDEMO_KEYEDDATABLOCK_HPP_
 
-//#include "ddpdemo/StorageKey.hpp"
+#include "ddpdemo/StorageKey.hpp"
 #include <cstdint>
 #include <memory>
 
@@ -24,11 +24,12 @@ struct KeyedDataBlock
 public:
 
   // These data members will be made private, at some point in time.
-  //StorageKey key;
-  uint32_t event_number;  // will be replaced with "key"
+  StorageKey data_key;
   size_t data_size;
   const uint8_t* unowned_data_start;
   std::unique_ptr<uint8_t> owned_data_start;
+
+  KeyedDataBlock(StorageKey theKey): data_key(theKey) {}
 
   const uint8_t* getDataStart() const
   {

--- a/include/ddpdemo/KeyedDataBlock.hpp
+++ b/include/ddpdemo/KeyedDataBlock.hpp
@@ -1,0 +1,54 @@
+/**
+ * @file KeyedDataBlock.hpp
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef DDPDEMO_INCLUDE_DDPDEMO_KEYEDDATABLOCK_HPP_
+#define DDPDEMO_INCLUDE_DDPDEMO_KEYEDDATABLOCK_HPP_
+
+//#include "ddpdemo/StorageKey.hpp"
+#include <cstdint>
+#include <memory>
+
+namespace dunedaq {
+namespace ddpdemo {
+
+/**
+ * @brief comment
+ */
+struct KeyedDataBlock
+{
+public:
+
+  // These data members will be made private, at some point in time.
+  //StorageKey key;
+  uint32_t event_number;  // will be replaced with "key"
+  size_t data_size;
+  const uint8_t* unowned_data_start;
+  std::unique_ptr<uint8_t> owned_data_start;
+
+  const uint8_t* getDataStart() const
+  {
+    if (owned_data_start.get() != nullptr)
+    {
+      return owned_data_start.get();
+    }
+    else
+    {
+      return unowned_data_start;
+    }
+  }
+
+  size_t getDataSizeBytes() const
+  {
+    return data_size;
+  }
+};
+
+} // namespace ddpdemo
+} // namespace dunedaq
+
+#endif // DDPDEMO_INCLUDE_DDPDEMO_KEYEDDATABLOCK_HPP_

--- a/src/SimpleDiskWriter.cpp
+++ b/src/SimpleDiskWriter.cpp
@@ -123,11 +123,11 @@ SimpleDiskWriter::do_work(std::atomic<bool>& running_flag)
     ers::debug(ProgressUpdate(ERS_HERE, get_name(), oss_prog.str()));
 
     // Here is where we will eventually write the data out to disk
-    KeyedDataBlock dataBlock;
-    dataBlock.event_number = generatedCount;
+    StorageKey dataKey(generatedCount, "FELIX", 101);
+    KeyedDataBlock dataBlock(dataKey);
     dataBlock.data_size = theFakeEvent.size() * sizeof(int);
     dataBlock.unowned_data_start = reinterpret_cast<uint8_t*>(&theFakeEvent[0]);
-    TLOG(TLVL_WORK_STEPS) << get_name() << ": size of fake event number " << dataBlock.event_number
+    TLOG(TLVL_WORK_STEPS) << get_name() << ": size of fake event number " << dataBlock.data_key.getEventID()
                           << " is " << dataBlock.data_size << " bytes.";
     // ++writtenCount;
 

--- a/src/SimpleDiskWriter.cpp
+++ b/src/SimpleDiskWriter.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "SimpleDiskWriter.hpp"
+#include "ddpdemo/KeyedDataBlock.hpp"
 
 #include <ers/ers.h>
 #include <TRACE/trace.h>
@@ -122,6 +123,12 @@ SimpleDiskWriter::do_work(std::atomic<bool>& running_flag)
     ers::debug(ProgressUpdate(ERS_HERE, get_name(), oss_prog.str()));
 
     // Here is where we will eventually write the data out to disk
+    KeyedDataBlock dataBlock;
+    dataBlock.event_number = generatedCount;
+    dataBlock.data_size = theFakeEvent.size() * sizeof(int);
+    dataBlock.unowned_data_start = reinterpret_cast<uint8_t*>(&theFakeEvent[0]);
+    TLOG(TLVL_WORK_STEPS) << get_name() << ": size of fake event number " << dataBlock.event_number
+                          << " is " << dataBlock.data_size << " bytes.";
     // ++writtenCount;
 
     TLOG(TLVL_WORK_STEPS) << get_name() << ": Start of sleep between sends";

--- a/src/SimpleDiskWriter.hpp
+++ b/src/SimpleDiskWriter.hpp
@@ -14,8 +14,6 @@
 
 #include "appfwk/DAQModule.hpp"
 #include "appfwk/ThreadHelper.hpp"
-#include "ddpdemo/StorageKey.hpp"
-
 
 #include <ers/Issue.h>
 


### PR DESCRIPTION
As part of validating the changes in this pull request, it would be nice to see that the TRACE message that prints out the event number from the StorageKey and the data size from the KeyedDataBlock is working.

Recall that to see the TRACE messages, one can use the following extra steps:
* `export TRACE_FILE=<MyTopDir>/log/<username>_dunedaq.trace`
* run the application to get the TRACE names populated in the TRACE buffer, if needed
* `tonM -n SimpleDiskWriter 15`
* re-run the application to get the TRACE messages printed out to the TRACE buffer
* `tshow | tdelta -ct 1` to view the TRACE messages (in reverse order, with human-readable timestamps)
