### PR TITLE
Feature/issue7 data store

### DIFF
--- a/include/ddpdemo/DataStore.hpp
+++ b/include/ddpdemo/DataStore.hpp
@@ -12,10 +12,10 @@
 // 09-Sep-2020, KAB: the initial version of this class was based on the
 // Queue interface from the appfwk repo.
 
-#ifndef DPPDEMO_INCLUDE_DPPDEMO_DATASTORE_HPP_
-#define DPPDEMO_INCLUDE_DPPDEMO_DATASTORE_HPP_
+#ifndef DDPDEMO_INCLUDE_DDPDEMO_DATASTORE_HPP_
+#define DDPDEMO_INCLUDE_DDPDEMO_DATASTORE_HPP_
 
-#include "dppdemo/KeyedDataBlock.hpp"
+#include "ddpdemo/KeyedDataBlock.hpp"
 #include "appfwk/NamedObject.hpp"
 
 #include <ers/Issue.h>
@@ -27,12 +27,12 @@
 #include <vector>
 
 namespace dunedaq {
-namespace dppdemo {
+namespace ddpdemo {
 
 /**
  * @brief comment
  */
-class DataStore : public NamedObject
+class DataStore : public appfwk::NamedObject
 {
 public:
 
@@ -41,7 +41,7 @@ public:
    * @param name Name of the DataStore instance
    */
   explicit DataStore(const std::string& name)
-    : NamedObject(name)
+    : appfwk::NamedObject(name)
   {}
 
   /**
@@ -62,7 +62,7 @@ private:
   DataStore& operator=(DataStore&&) = default;
 };
 
-} // namespace dppdemo
+} // namespace ddpdemo
 } // namespace dunedaq
 
-#endif // DPPDEMO_INCLUDE_DPPDEMO_DATASTORE_HPP_
+#endif // DDPDEMO_INCLUDE_DDPDEMO_DATASTORE_HPP_

--- a/include/ddpdemo/DataStore.hpp
+++ b/include/ddpdemo/DataStore.hpp
@@ -1,0 +1,68 @@
+/**
+ * @file DataStore.hpp
+ *
+ * This is the interface for storing and retrieving data from
+ * various storage systems.
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+// 09-Sep-2020, KAB: the initial version of this class was based on the
+// Queue interface from the appfwk repo.
+
+#ifndef DPPDEMO_INCLUDE_DPPDEMO_DATASTORE_HPP_
+#define DPPDEMO_INCLUDE_DPPDEMO_DATASTORE_HPP_
+
+#include "dppdemo/KeyedDataBlock.hpp"
+#include "appfwk/NamedObject.hpp"
+
+#include <ers/Issue.h>
+
+#include <chrono>
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace dunedaq {
+namespace dppdemo {
+
+/**
+ * @brief comment
+ */
+class DataStore : public NamedObject
+{
+public:
+
+  /**
+   * @brief DataStore Constructor
+   * @param name Name of the DataStore instance
+   */
+  explicit DataStore(const std::string& name)
+    : NamedObject(name)
+  {}
+
+  /**
+   * @brief Writes the specified data payload into the DataStore.
+   * @param dataBlock Data block to write.
+   */
+  virtual void write(const KeyedDataBlock& dataBlock) = 0;
+
+  // Ideas for future work...
+  //virtual void write(const std::vector<KeyedDataBlock>& dataBlockList) = 0;
+  //virtual KeyedDataBlock read(const StorageKey& key) = 0;
+  //virtual std::vector<KeyedDataBlock> read(const std::vector<StorageKey>& key) = 0;
+
+private:
+  DataStore(const DataStore&) = delete;
+  DataStore& operator=(const DataStore&) = delete;
+  DataStore(DataStore&&) = default;
+  DataStore& operator=(DataStore&&) = default;
+};
+
+} // namespace dppdemo
+} // namespace dunedaq
+
+#endif // DPPDEMO_INCLUDE_DPPDEMO_DATASTORE_HPP_

--- a/include/ddpdemo/TrashCanDataStore.hpp
+++ b/include/ddpdemo/TrashCanDataStore.hpp
@@ -1,0 +1,58 @@
+#ifndef DDPDEMO_INCLUDE_DDPDEMO_TRASHCANDATASTORE_HPP_
+#define DDPDEMO_INCLUDE_DDPDEMO_TRASHCANDATASTORE_HPP_
+
+/**
+ * @file TrashCanDataStore.hpp
+ *
+ * An implementation of the DataStore interface that simply throws
+ * data away instead of storing it.  Obviously, this class is just
+ * for demonstration and testing purposes.
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "ddpdemo/DataStore.hpp"
+
+#include <ers/Issue.h>
+
+#include <iomanip>
+
+namespace dunedaq {
+namespace ddpdemo {
+
+class TrashCanDataStore : public DataStore
+{
+public:
+
+  explicit TrashCanDataStore(const std::string& name)
+    : DataStore(name)
+  {}
+
+  virtual void write(const KeyedDataBlock& dataBlock)
+  {
+    const uint8_t* dataPtr = dataBlock.getDataStart();
+    ERS_INFO("Throwing away the data from event ID " << dataBlock.data_key.getEventID() <<
+             ", which has size of " << dataBlock.data_size << " bytes, and the following data " <<
+             "in the first few bytes: 0x" << std::hex << std::setfill('0') << std::setw(2) <<
+             ((int)dataPtr[0]) << " 0x" << ((int)dataPtr[1]) << " 0x" << ((int)dataPtr[2]) <<
+             " 0x" << ((int)dataPtr[3]) << std::dec);
+  }
+
+private:
+  // Delete the copy and move operations
+  TrashCanDataStore(const TrashCanDataStore&) = delete;
+  TrashCanDataStore& operator=(const TrashCanDataStore&) = delete;
+  TrashCanDataStore(TrashCanDataStore&&) = delete;
+  TrashCanDataStore& operator=(TrashCanDataStore&&) = delete;
+};
+
+} // namespace ddpdemo
+} // namespace dunedaq
+
+#endif // DDPDEMO_INCLUDE_DDPDEMO_TRASHCANDATASTORE_HPP_
+
+// Local Variables:
+// c-basic-offset: 2
+// End:

--- a/src/SimpleDiskWriter.cpp
+++ b/src/SimpleDiskWriter.cpp
@@ -8,6 +8,7 @@
 
 #include "SimpleDiskWriter.hpp"
 #include "ddpdemo/KeyedDataBlock.hpp"
+#include "ddpdemo/TrashCanDataStore.hpp"
 
 #include <ers/ers.h>
 #include <TRACE/trace.h>
@@ -39,6 +40,7 @@ SimpleDiskWriter::SimpleDiskWriter(const std::string& name)
 void SimpleDiskWriter::init()
 {
   TLOG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering init() method";
+  dataWriter_.reset(new TrashCanDataStore("TempName"));
   TLOG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting init() method";
 }
 
@@ -129,7 +131,8 @@ SimpleDiskWriter::do_work(std::atomic<bool>& running_flag)
     dataBlock.unowned_data_start = reinterpret_cast<uint8_t*>(&theFakeEvent[0]);
     TLOG(TLVL_WORK_STEPS) << get_name() << ": size of fake event number " << dataBlock.data_key.getEventID()
                           << " is " << dataBlock.data_size << " bytes.";
-    // ++writtenCount;
+    dataWriter_->write(dataBlock);
+    ++writtenCount;
 
     TLOG(TLVL_WORK_STEPS) << get_name() << ": Start of sleep between sends";
     std::this_thread::sleep_for(std::chrono::milliseconds(waitBetweenSendsMsec_));

--- a/src/SimpleDiskWriter.hpp
+++ b/src/SimpleDiskWriter.hpp
@@ -12,6 +12,8 @@
 #ifndef DDPDEMO_SRC_SIMPLEDISKWRITER_HPP_
 #define DDPDEMO_SRC_SIMPLEDISKWRITER_HPP_
 
+#include "ddpdemo/DataStore.hpp"
+
 #include "appfwk/DAQModule.hpp"
 #include "appfwk/ThreadHelper.hpp"
 
@@ -66,6 +68,9 @@ private:
   // Configuration
   size_t nIntsPerFakeEvent_ = REASONABLE_DEFAULT_INTSPERFAKEEVENT;
   size_t waitBetweenSendsMsec_ = REASONABLE_DEFAULT_MSECBETWEENSENDS;
+
+  // Workers
+  std::unique_ptr<DataStore> dataWriter_;
 };
 } // namespace ddpdemo
 


### PR DESCRIPTION
As I described in Issue #7, I created an initial DataStore interface to give us an implementation-neutral way to store data.  To provide a simple way to test this interface, I created the TrashCanDataStore class (which throws the data away instead of storing it anywhere).  
To demonstrate these chances, I hacked SimpleDiskWriter.cpp to make use of a TrashCanDataStore, and the modified code seems to work.
As part of validating these changes, it would be great to run the DiskWriterDemo JSON configuration and see the messages on the console from the TrashCanDataWriter.
