### PR TITLE
Feature/issue26 data store reader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,11 +29,8 @@ target_link_libraries(ddpdemo_BinaryWriter_duneDAQModule appfwk::appfwk ddpdemo 
 daq_point_build_to( test )
 
 file(COPY test/disk_writer_demo.json DESTINATION test)
-<<<<<<< HEAD
 file(COPY test/disk_reader_demo.json DESTINATION test)
-=======
 file(COPY test/binary_writer_demo.json DESTINATION test)
->>>>>>> develop
 
 ##############################################################################
 daq_point_build_to( unittest )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,10 +22,14 @@ target_link_libraries(ddpdemo ers::ers)
 add_library(ddpdemo_SimpleDiskWriter_duneDAQModule src/SimpleDiskWriter.cpp)
 target_link_libraries(ddpdemo_SimpleDiskWriter_duneDAQModule appfwk::appfwk ddpdemo HighFive)
 
+add_library(ddpdemo_SimpleDiskReader_duneDAQModule src/SimpleDiskReader.cpp)
+target_link_libraries(ddpdemo_SimpleDiskReader_duneDAQModule appfwk::appfwk ddpdemo HighFive)
+
 ##############################################################################
 daq_point_build_to( test )
 
 file(COPY test/disk_writer_demo.json DESTINATION test)
+file(COPY test/disk_reader_demo.json DESTINATION test)
 
 ##############################################################################
 daq_point_build_to( unittest )
@@ -33,6 +37,7 @@ daq_add_unit_test(StorageKey_test          ddpdemo ers::ers)
  
 ##############################################################################
 
-daq_install(TARGETS ddpdemo ddpdemo_SimpleDiskWriter_duneDAQModule )
+daq_install(TARGETS ddpdemo ddpdemo_SimpleDiskWriter_duneDAQModule ddpdemo_SimpleDiskReader_duneDAQModule)
+
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,9 @@ target_link_libraries(ddpdemo_SimpleDiskWriter_duneDAQModule appfwk::appfwk ddpd
 add_library(ddpdemo_BinaryWriter_duneDAQModule src/BinaryWriter.cpp)
 target_link_libraries(ddpdemo_BinaryWriter_duneDAQModule appfwk::appfwk ddpdemo HighFive)
 
+add_library(ddpdemo_SimpleDiskReader_duneDAQModule src/SimpleDiskReader.cpp)
+target_link_libraries(ddpdemo_SimpleDiskReader_duneDAQModule appfwk::appfwk ddpdemo HighFive)
+
 ##############################################################################
 daq_point_build_to( test )
 
@@ -38,7 +41,4 @@ daq_add_unit_test(StorageKey_test          ddpdemo ers::ers)
  
 ##############################################################################
 
-daq_install(TARGETS ddpdemo ddpdemo_SimpleDiskWriter_duneDAQModule ddpdemo_BinaryWriter_duneDAQModule)
-
-
-
+daq_install(TARGETS ddpdemo ddpdemo_SimpleDiskWriter_duneDAQModule ddpdemo_BinaryWriter_duneDAQModule ddpdemo_SimpleDiskReader_duneDAQModule)

--- a/include/ddpdemo/DataStore.hpp
+++ b/include/ddpdemo/DataStore.hpp
@@ -61,7 +61,7 @@ public:
 
   // Ideas for future work...
   //virtual void write(const std::vector<KeyedDataBlock>& dataBlockList) = 0;
-  //virtual KeyedDataBlock read(const StorageKey& key) = 0;
+  virtual KeyedDataBlock read(const StorageKey& key) = 0;
   //virtual std::vector<KeyedDataBlock> read(const std::vector<StorageKey>& key) = 0;
 
 private:

--- a/include/ddpdemo/HDF5DataReader.hpp
+++ b/include/ddpdemo/HDF5DataReader.hpp
@@ -42,10 +42,9 @@ public:
 
 
   }
-  virtual void setup(const std::string path, const std::string fileName) {
-    ERS_INFO("Setting up ... " << path + fileName);
+  virtual void setup(const size_t eventId) {
+    ERS_INFO("Setup ... " << eventId);
   }
-
 
 
   virtual void write(const KeyedDataBlock& dataBlock) { // this is here just as a place holder and in order to use DataStore as a class 

--- a/include/ddpdemo/HDF5DataReader.hpp
+++ b/include/ddpdemo/HDF5DataReader.hpp
@@ -1,0 +1,111 @@
+#ifndef DDPDEMO_INCLUDE_DDPDEMO_HDF5DATAREADER_HPP_
+#define DDPDEMO_INCLUDE_DDPDEMO_HDF5DATAREADER_HPP_
+
+/**
+ * @file HDF5DataReader.hpp
+ *
+ * An implementation of the HDF5DataReader class that simply reads
+ * data but it does not store it.  Obviously, this class is just
+ * for demonstration and testing purposes.
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "ddpdemo/DataStore.hpp"
+
+#include <ers/Issue.h>
+#include <TRACE/trace.h>
+
+
+//#include "H5Cpp.h"
+#include "highfive/H5File.hpp"
+#include "highfive/H5DataSet.hpp"
+#include "highfive/H5Easy.hpp"
+
+
+namespace dunedaq {
+namespace ddpdemo {
+
+
+class HDF5DataReader : public DataStore {
+
+public:
+  explicit HDF5DataReader(const std::string name, const std::string& path, const std::string& fileName) : DataStore(name) {
+
+  ERS_INFO("Directory path: " << path );
+  ERS_INFO("Filename: " << fileName);
+
+  filePtr = new HighFive::File(path + fileName, HighFive::File::ReadOnly);
+  ERS_INFO("Opened HDF5 file in ReadOnly mode");
+
+
+  }
+  virtual void setup(const std::string path, const std::string fileName) {
+    ERS_INFO("Setting up ... " << path + fileName);
+  }
+
+
+
+  virtual void write(const KeyedDataBlock& dataBlock) { // this is here just as a place holder and in order to use DataStore as a class 
+    ERS_INFO("Screen print data from event ID " << dataBlock.data_key.getEventID() <<
+             ", which has size of " << dataBlock.data_size );
+  }
+
+
+  virtual KeyedDataBlock read(const StorageKey& key) {
+    ERS_INFO("reading data block from event ID " << key.getEventID() <<
+             ", detector ID " << key.getDetectorID() << ", geoLocation "<< key.getGeoLocation());
+  
+    const std::string groupName = std::to_string(key.getEventID());
+    const std::string detectorID = key.getDetectorID();
+    const std::string datasetName = std::to_string(key.getGeoLocation());
+    const std::string keyFragment = groupName+':'+detectorID+':'+datasetName;
+    KeyedDataBlock dataBlock(key) ; 
+    if(!filePtr->exist(groupName)) {
+       throw InvalidDataReaderError(ERS_HERE, get_name());
+    } else {
+      HighFive::Group theGroup = filePtr->getGroup(groupName);
+       if (!theGroup.isValid()) {
+          throw InvalidDataReaderError(ERS_HERE, get_name());
+       } else {
+          try {  // to determine if the dataset exists in the group
+             HighFive::DataSet theDataSet = theGroup.getDataSet( datasetName );
+             ERS_INFO("reading fragment " <<keyFragment<<  ", with storage size "<<theDataSet.getStorageSize());
+             dataBlock.data_size = theDataSet.getStorageSize();
+             //             dataBlock.owned_data_start = theDataSet.getStorageSize();
+             
+          }
+          catch( HighFive::DataSetException const& ) {
+             ERS_INFO("HDF5DataSet "<< datasetName << " not found.");
+          }
+       }
+    }
+    return dataBlock;
+  }
+
+
+
+
+private: 
+  HDF5DataReader(const HDF5DataReader&) = delete;
+  HDF5DataReader& operator=(const HDF5DataReader&) = delete;
+  HDF5DataReader(HDF5DataReader&&) = delete;
+  HDF5DataReader& operator=(HDF5DataReader&&) = delete;
+
+  HighFive::File* filePtr; 
+
+};
+
+
+} // namespace ddpdemo
+} // namespace dunedaq
+  // Operator function
+
+#endif // DDPDEMO_INCLUDE_DDPDEMO_HDF5DATASTORE_HPP_
+
+// Local Variables:
+// c-basic-offset: 2
+// End:
+

--- a/include/ddpdemo/HDF5DataStore.hpp
+++ b/include/ddpdemo/HDF5DataStore.hpp
@@ -44,7 +44,13 @@ public:
   virtual void setup(const std::string path, const std::string fileName) {
      ERS_INFO("Setting up ... " << path + fileName);
   }
-
+  
+  virtual KeyedDataBlock read(const StorageKey& data_key) {
+     ERS_INFO("reading data block from event ID " << data_key.getEventID() <<
+             ", detector ID " << data_key.getDetectorID() << ", geoLocation "<< data_key.getGeoLocation());   
+     KeyedDataBlock dataBlock(data_key);
+     return  dataBlock; 
+  }
 
 
   virtual void write(const KeyedDataBlock& dataBlock) {

--- a/src/SimpleDiskReader.cpp
+++ b/src/SimpleDiskReader.cpp
@@ -1,0 +1,152 @@
+/**
+ * @file SimpleDiskReader.cpp SimpleDiskReader class implementation
+ *
+ * This is part of the DUNE DAQ Software Suite, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#include "SimpleDiskReader.hpp"
+#include "ddpdemo/KeyedDataBlock.hpp"
+#include "ddpdemo/HDF5DataReader.hpp"
+
+#include <ers/ers.h>
+#include <TRACE/trace.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <thread>
+
+/**
+ * @brief Name used by TRACE TLOG calls from this source file
+ */
+#define TRACE_NAME "SimpleDiskReader" // NOLINT
+#define TLVL_ENTER_EXIT_METHODS 10
+#define TLVL_WORK_STEPS 15
+
+namespace dunedaq {
+namespace ddpdemo {
+
+SimpleDiskReader::SimpleDiskReader(const std::string& name)
+  : dunedaq::appfwk::DAQModule(name)
+  , thread_(std::bind(&SimpleDiskReader::do_work, this, std::placeholders::_1))
+{
+  register_command("configure", &SimpleDiskReader::do_configure);
+  register_command("start",  &SimpleDiskReader::do_start);
+  register_command("stop",  &SimpleDiskReader::do_stop);
+  register_command("unconfigure",  &SimpleDiskReader::do_unconfigure);
+}
+
+void SimpleDiskReader::init()
+{
+  TLOG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering init() method";
+  TLOG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting init() method";
+}
+
+void
+SimpleDiskReader::do_configure(const std::vector<std::string>& /*args*/)
+{
+  TLOG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering do_configure() method";
+  key_eventID_ = get_config().value<size_t>("event_id", static_cast<size_t>(REASONABLE_DEFAULT_MSECBETWEENSENDS));
+  key_detectorID_ = get_config()["detector_id"].get<std::string>();
+  key_geoLocationID_ = get_config().value<size_t>("geolocation_id", static_cast<size_t>(REASONABLE_DEFAULT_MSECBETWEENSENDS));
+  waitBetweenSendsMsec_ = get_config().value<size_t>("waitBetweenSendsMsec", static_cast<size_t>(REASONABLE_DEFAULT_MSECBETWEENSENDS));
+
+  directory_path_ = get_config()["data_store_parameters"]["directory_path"].get<std::string>();
+  filename_pattern_ = get_config()["data_store_parameters"]["filename_pattern"].get<std::string>();
+
+  // Initializing the HDF5 DataStore constructor
+  // Creating empty HDF5 file
+  dataReader_.reset(new HDF5DataReader("tempReader", directory_path_ , filename_pattern_));
+
+
+  TLOG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting do_configure() method";
+}
+
+void
+SimpleDiskReader::do_start(const std::vector<std::string>& /*args*/)
+{
+  TLOG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering do_start() method";
+  thread_.start_working_thread();
+  ERS_LOG(get_name() << " successfully started");
+  TLOG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting do_start() method";
+}
+
+void
+SimpleDiskReader::do_stop(const std::vector<std::string>& /*args*/)
+{
+  TLOG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering do_stop() method";
+  thread_.stop_working_thread();
+  ERS_LOG(get_name() << " successfully stopped");
+  TLOG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting do_stop() method";
+}
+
+void
+SimpleDiskReader::do_unconfigure(const std::vector<std::string>& /*args*/)
+{
+  TLOG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering do_unconfigure() method";
+  //  nIntsPerFakeEvent_ = REASONABLE_DEFAULT_INTSPERFAKEEVENT;
+  waitBetweenSendsMsec_ = REASONABLE_DEFAULT_MSECBETWEENSENDS;
+  TLOG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting do_unconfigure() method";
+}
+
+/**
+ * @brief Format a std::vector<int> to a stream
+ * @param t ostream Instance
+ * @param ints Vector to format
+ * @return ostream Instance
+ */
+std::ostream&
+operator<<(std::ostream& t, std::vector<int> ints)
+{
+  t << "{";
+  bool first = true;
+  for (auto& i : ints) {
+    if (!first)
+      t << ", ";
+    first = false;
+    t << i;
+  }
+  return t << "}";
+
+}
+
+void
+SimpleDiskReader::do_work(std::atomic<bool>& running_flag)
+{
+  TLOG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Entering do_work() method";
+  size_t generatedCount = 0;
+  size_t writtenCount = 0;
+
+  // ensure that we have a valid dataReader instance
+  if (dataReader_.get() == nullptr)
+  {
+    throw InvalidDataReaderError(ERS_HERE, get_name());
+  }
+
+  while (running_flag.load()) {
+    TLOG(TLVL_WORK_STEPS) << get_name() << ": reading fakeEvent  " ;
+
+    StorageKey dataKey(key_eventID_, key_detectorID_, key_geoLocationID_ );
+
+    TLOG(TLVL_WORK_STEPS) << get_name() << ": trying to read fragment " <<key_eventID_<<":"<< key_detectorID_<<":"<< key_geoLocationID_  <<", from file "<<filename_pattern_ ;
+
+    auto dataBlock  = dataReader_->read(dataKey);
+    ++writtenCount;
+
+    TLOG(TLVL_WORK_STEPS) << get_name() << ": Start of sleep between sends";
+    std::this_thread::sleep_for(std::chrono::milliseconds(waitBetweenSendsMsec_));
+    TLOG(TLVL_WORK_STEPS) << get_name() << ": End of do_work loop";
+  }
+
+  std::ostringstream oss_summ;
+  oss_summ << ": Exiting the do_work() method, read " << generatedCount
+           << " fake events and successfully read " << writtenCount << " of them to disk. ";
+  ers::info(ProgressUpdate(ERS_HERE, get_name(), oss_summ.str()));
+  TLOG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting do_work() method";
+}
+
+} // namespace ddpdemo 
+} // namespace dunedaq
+
+DEFINE_DUNE_DAQ_MODULE(dunedaq::ddpdemo::SimpleDiskReader)

--- a/src/SimpleDiskReader.hpp
+++ b/src/SimpleDiskReader.hpp
@@ -1,0 +1,103 @@
+/**
+ * @file SimpleDiskReader.hpp
+ *
+ * SimpleDiskReader is a simple DAQModule implementation that
+ * periodically writes data to an HDF5 file on disk.
+ *
+ * This is part of the DUNE DAQ Software Suite, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef DDPDEMO_SRC_SIMPLEDISKREADER_HPP_
+#define DDPDEMO_SRC_SIMPLEDISKREADER_HPP_
+
+#include "ddpdemo/DataStore.hpp"
+
+#include "appfwk/DAQModule.hpp"
+#include "appfwk/ThreadHelper.hpp"
+
+#include <ers/Issue.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace dunedaq {
+namespace ddpdemo {
+
+/**
+ * @brief SimpleDiskReader reads fake events and dumps them on the screen
+ * them to an HDF5 file..
+ */
+class SimpleDiskReader : public dunedaq::appfwk::DAQModule
+{
+public:
+  /**
+   * @brief SimpleDiskReader Constructor
+   * @param name Instance name for this SimpleDiskReader instance
+   */
+  explicit SimpleDiskReader(const std::string& name);
+
+  SimpleDiskReader(const SimpleDiskReader&) =
+    delete; ///< SimpleDiskReader is not copy-constructible
+  SimpleDiskReader& operator=(const SimpleDiskReader&) =
+    delete; ///< SimpleDiskReader is not copy-assignable
+  SimpleDiskReader(SimpleDiskReader&&) =
+    delete; ///< SimpleDiskReader is not move-constructible
+  SimpleDiskReader& operator=(SimpleDiskReader&&) =
+    delete; ///< SimpleDiskReader is not move-assignable
+
+  void init() override;
+
+private:
+  // Commands
+  void do_configure(const std::vector<std::string>& args);
+  void do_start(const std::vector<std::string>& args);
+  void do_stop(const std::vector<std::string>& args);
+  void do_unconfigure(const std::vector<std::string>& args);
+
+  // Threading
+  dunedaq::appfwk::ThreadHelper thread_;
+  void do_work(std::atomic<bool>&);
+
+  // Configuration defaults
+  const size_t REASONABLE_DEFAULT_INTFRAGMENT = 1;
+  const size_t REASONABLE_DEFAULT_MSECBETWEENSENDS = 1000;
+
+  const std::string DEFAULT_PATH = ".";
+  const std::string DEFAULT_FILENAME = "demo.hdf5";
+
+  // Configuration
+  size_t key_eventID_ = REASONABLE_DEFAULT_INTFRAGMENT;
+  std::string key_detectorID_ = "FELIX" ;
+  size_t key_geoLocationID_ = REASONABLE_DEFAULT_INTFRAGMENT;
+  size_t waitBetweenSendsMsec_ = REASONABLE_DEFAULT_MSECBETWEENSENDS;
+
+
+  std::string directory_path_ = DEFAULT_PATH;
+  std::string filename_pattern_ = DEFAULT_FILENAME;
+
+  // Workers
+  std::unique_ptr<DataStore> dataReader_;
+};
+} // namespace ddpdemo
+
+ERS_DECLARE_ISSUE_BASE(ddpdemo,
+                       ProgressUpdate,
+                       appfwk::GeneralDAQModuleIssue,
+                       message,
+                       ((std::string)name),
+                       ((std::string)message))
+
+ERS_DECLARE_ISSUE_BASE(ddpdemo,
+                       InvalidDataReaderError,
+                       appfwk::GeneralDAQModuleIssue,
+                       "A valid dataReader instance is not available so it will not be possible to read data. A likely cause for this is a skipped or missed Configure transition.",
+                       ((std::string)name),
+                       ERS_EMPTY)
+
+
+} // namespace dunedaq
+
+#endif // DDPDEMO_SRC_SIMPLEDISKREADER_HPP_

--- a/test/disk_reader_demo.json
+++ b/test/disk_reader_demo.json
@@ -1,0 +1,23 @@
+{
+  "queues": {
+  },
+  "modules": {
+    "disk_reader": {
+      "user_module_type": "SimpleDiskReader",
+      "waitBetweenSendsMsec": 1000,
+      "event_id": 1,
+      "detector_id": "FELIX",
+      "geolocation_id": 1,
+
+      "data_store_parameters": {
+      "data_store_module": "HDF5DataReader",
+      "directory_path": "./",
+      "filename_pattern": "demo_event_1.hdf5"
+      }
+    }
+  },
+  "commands": {
+    "start": [ "disk_reader" ],
+    "stop": [ "disk_reader" ]
+  }
+}


### PR DESCRIPTION
Here is the summary of my PR:
Added yet another module : ddpdemo_SimpleDiskReader_duneDAQModule
That takes test/disk_reader_demo.json in the usual way and reads a file specified in the usual path and reads a single fragment give by a StorageKey  (for testing this key can be configured in the json file)
The reading method is implemented in HDF5DataReader.hpp &  HDF5DataReader.cpp
This will need to be merged with HDF5DataStorage.xpp  in the future, but for now while developing the other reading methods I will leave it not merged yet.
