### PR TITLE
Feature/issue26 data store reader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ daq_point_build_to( unittest )
 daq_add_unit_test(HDF5KeyTranslator_test   appfwk::appfwk ddpdemo ers::ers)
 daq_add_unit_test(StorageKey_test          ddpdemo ers::ers)
 daq_add_unit_test(HDF5Write_test           appfwk::appfwk ddpdemo ers::ers HighFive stdc++fs)
+daq_add_unit_test(HDF5WriteAndRead_test           appfwk::appfwk ddpdemo ers::ers HighFive stdc++fs)
 
 ##############################################################################
 

--- a/include/ddpdemo/HDF5DataReader.hpp
+++ b/include/ddpdemo/HDF5DataReader.hpp
@@ -61,7 +61,7 @@ public:
     ERS_INFO("going to read data block from eventID/geoLocationID " << HDF5KeyTranslator::getPathString(key));
   
     const std::string groupName = std::to_string(key.getEventID());
-    const std::string detectorID = key.getDetectorID();
+    //    const std::string detectorID = key.getDetectorID();
     const std::string datasetName = std::to_string(key.getGeoLocation());
     KeyedDataBlock dataBlock(key) ; 
 

--- a/src/SimpleDiskReader.cpp
+++ b/src/SimpleDiskReader.cpp
@@ -129,11 +129,13 @@ SimpleDiskReader::do_work(std::atomic<bool>& running_flag)
 
   TLOG(TLVL_WORK_STEPS) << get_name() << ": trying to read fragment " <<key_eventID_<<":"<< key_detectorID_<<":"<< key_geoLocationID_  <<", from file "<<filename_pattern_ ;
 
-  KeyedDataBlock dataBlock  = dataReader_->read(dataKey);
+  KeyedDataBlock dataBlock(dataKey) ; //= dataReader_->read(dataKey);
 
   while (running_flag.load()) {
       // for now just read the file/datafragment and then stop
     std::this_thread::sleep_for(std::chrono::milliseconds(waitBetweenSendsMsec_));
+    dataBlock  = dataReader_->read(dataKey);
+
   }
   
   TLOG(TLVL_WORK_STEPS) << get_name() << ": End of do_work loop";

--- a/src/SimpleDiskReader.cpp
+++ b/src/SimpleDiskReader.cpp
@@ -8,7 +8,7 @@
 
 #include "SimpleDiskReader.hpp"
 #include "ddpdemo/KeyedDataBlock.hpp"
-#include "ddpdemo/HDF5DataReader.hpp"
+#include "ddpdemo/HDF5DataStore.hpp"
 
 #include <ers/ers.h>
 #include <TRACE/trace.h>
@@ -53,11 +53,11 @@ SimpleDiskReader::do_configure(const std::vector<std::string>& /*args*/)
   waitBetweenSendsMsec_ = get_config().value<size_t>("waitBetweenSendsMsec", static_cast<size_t>(REASONABLE_DEFAULT_MSECBETWEENSENDS));
 
   directory_path_ = get_config()["data_store_parameters"]["directory_path"].get<std::string>();
-  filename_pattern_ = get_config()["data_store_parameters"]["filename_pattern"].get<std::string>();
-
-  // Initializing the HDF5 DataStore constructor
-  // Creating empty HDF5 file
-  dataReader_.reset(new HDF5DataReader("tempReader", directory_path_ , filename_pattern_));
+  filename_pattern_ = get_config()["data_store_parameters"]["filename"].get<std::string>();
+  operation_mode_ = get_config()["data_store_parameters"]["mode"].get<std::string>();
+  // Initializing the HDF5 DataStore constructor                                                                                               
+  // Creating empty HDF5 file                                                                                                                  
+  dataReader_.reset(new HDF5DataStore("tempWriter", directory_path_ , filename_pattern_, operation_mode_));
 
 
   TLOG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting do_configure() method";

--- a/src/SimpleDiskReader.hpp
+++ b/src/SimpleDiskReader.hpp
@@ -77,7 +77,7 @@ private:
 
   std::string directory_path_ = DEFAULT_PATH;
   std::string filename_pattern_ = DEFAULT_FILENAME;
-
+  std::string operation_mode_ = "" ;
   // Workers
   std::unique_ptr<DataStore> dataReader_;
 };

--- a/src/SimpleDiskWriter.cpp
+++ b/src/SimpleDiskWriter.cpp
@@ -52,10 +52,10 @@ SimpleDiskWriter::do_configure(const std::vector<std::string>& /*args*/)
 
   directory_path_ = get_config()["data_store_parameters"]["directory_path"].get<std::string>();
   filename_pattern_ = get_config()["data_store_parameters"]["filename_pattern"].get<std::string>();
-
+  operation_mode_ = get_config()["data_store_parameters"]["mode"].get<std::string>();
   // Initializing the HDF5 DataStore constructor
   // Creating empty HDF5 file
-  dataWriter_.reset(new HDF5DataStore("tempWriter", directory_path_ , filename_pattern_, ""));
+  dataWriter_.reset(new HDF5DataStore("tempWriter", directory_path_ , filename_pattern_, operation_mode_));
 
 
   TLOG(TLVL_ENTER_EXIT_METHODS) << get_name() << ": Exiting do_configure() method";

--- a/src/SimpleDiskWriter.hpp
+++ b/src/SimpleDiskWriter.hpp
@@ -75,6 +75,7 @@ private:
 
   std::string directory_path_ = DEFAULT_PATH;
   std::string filename_pattern_ = DEFAULT_FILENAME;
+  std::string operation_mode_ = "" ;
 
   // Workers
   std::unique_ptr<DataStore> dataWriter_;

--- a/test/disk_reader_demo.json
+++ b/test/disk_reader_demo.json
@@ -13,7 +13,7 @@
       "data_store_module": "HDF5DataReader",
       "directory_path": "./",
       "filename": "demo",
-      "mode": "one-event-per-file"
+      "mode": "one-fragment-per-file"
       }
     }
   },

--- a/test/disk_reader_demo.json
+++ b/test/disk_reader_demo.json
@@ -12,7 +12,8 @@
       "data_store_parameters": {
       "data_store_module": "HDF5DataReader",
       "directory_path": "./",
-      "filename_pattern": "demo_event_1.hdf5"
+      "filename": "demo",
+      "mode": "one-event-per-file"
       }
     }
   },

--- a/test/disk_writer_demo.json
+++ b/test/disk_writer_demo.json
@@ -10,7 +10,8 @@
       "data_store_parameters": {
       "data_store_module": "HDF5DataStore",
       "directory_path": ".",
-      "filename_pattern": "demo"
+      "filename_pattern": "demo",
+      "mode":"one-fragment-per-file"   
       }
     }
   },


### PR DESCRIPTION
This is a summary of the developments contained in this PR:

1 ) write() and read() methods implemented in HDF5DataStore.hpp 
1.1 ) these methods now use a new config parameter to specify an operational "mode" out of three : "one-fragment-per-file" , "one-event-per-file", "all-per-file" . 
1.2 ) the implementation of write() and read()  is agnostic about the operation "mode" as this is handle through utility functions 
1.3 ) the implementation of write() and read()  is agnostic about the opening of files as this is done through utility functions 

2) developed unittests to check for the new implementation features 

3) HDF5DataStore.hpp  make use of HDF5KeyTranslator ( collection of functions to translate between StorageKeys and HDF5 Group/DataSet )

